### PR TITLE
Correctif Gn

### DIFF
--- a/src/Api/Gn/Group.php
+++ b/src/Api/Gn/Group.php
@@ -1,12 +1,12 @@
 <?php
 /**
  * Ce fichier est développé pour la gestion de la lib MCE
- * 
+ *
  * Cette Librairie permet d'accèder aux données sans avoir à implémenter de couche SQL
  * Des objets génériques vont permettre d'accèder et de mettre à jour les données
- * 
+ *
  * ORM Mél Copyright © 2021 Groupe Messagerie/MTE
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -26,13 +26,13 @@ use LibMelanie\Config\Ldap as LdapConfig;
 
 /**
  * Classe groupe LDAP pour GN
- * 
+ *
  * @author Groupe Messagerie/MTE - Apitech
  * @package LibMCE
  * @subpackage API/GN
  * @api
- * 
- * @property string $dn DN du groupe l'annuaire 
+ *
+ * @property string $dn DN du groupe l'annuaire
  * @property string $fullname Nom complet du groupe LDAP
  * @property string $type Type de groupe (voir Mce\Users\Type::*)
  * @property string $email Adresse email principale de l'utilisateur
@@ -49,7 +49,7 @@ use LibMelanie\Config\Ldap as LdapConfig;
 class Group extends Defaut\Group {
     /**
      * Attributs par défauts pour la méthode load()
-     * 
+     *
      * @ignore
      */
     const LOAD_ATTRIBUTES = ['dn', 'fullname', 'email', 'owners', 'cn'];
@@ -57,7 +57,7 @@ class Group extends Defaut\Group {
     /**
      * Récupère la liste des membres d'un groupe
      * On ne "load" pas les membres, car certains groupes sont trop grand => trop de requêtes
-     * 
+     *
      * @return array|Defaut\User[]
      */
     public function getMapMembers() {
@@ -70,21 +70,14 @@ class Group extends Defaut\Group {
             $search = $ldap->search($ldap->getConfig("base_dn"), $filter);
             $entries = $ldap->get_entries($search);
 
-            $attributesMember = $ldap->getConfig('get_user_infos_attributes');
-
             if ($entries
                     && is_array($entries)
                     && $entries['count'] > 0) {
                 array_shift($entries);
                 foreach ($entries as $i => $entry) {
                     $member = new Member();
-                    foreach ($attributesMember as $k) {
-                        if (isset($entry[$k])) {
-                            $member->$k = $entry[$k][0];
-                        } else {
-                            $member->$k = null;
-                        }
-                    }
+                    $member->dn = $entry['dn'];
+                    $member->load();//pour avoir le mail
                     $this->_members[] = $member;
                 }
             }

--- a/src/Api/Gn/Group.php
+++ b/src/Api/Gn/Group.php
@@ -99,4 +99,11 @@ class Group extends Defaut\Group {
 
         return $this->getMapMembers();
     }
+
+    public function setMapCn($cn)
+    {
+        $ldap = Ldap::GetInstance(LdapConfig::$SEARCH_LDAP);
+        $base_group = $ldap->getConfig("base_group_dn");
+        $this->dn = "cn=$cn,$base_group";
+    }
 }

--- a/src/Api/Gn/Group.php
+++ b/src/Api/Gn/Group.php
@@ -68,6 +68,7 @@ class Group extends Defaut\Group {
             $filter = $ldap->getConfig("get_users_by_group");
             $filter = str_replace("%%memberOf%%", $this->dn, $filter);
             $search = $ldap->search($ldap->getConfig("base_dn"), $filter);
+            $attributes = $ldap->getConfig("get_user_infos_attributes");
             $entries = $ldap->get_entries($search);
 
             if ($entries
@@ -77,7 +78,7 @@ class Group extends Defaut\Group {
                 foreach ($entries as $i => $entry) {
                     $member = new Member();
                     $member->dn = $entry['dn'];
-                    $member->load();//pour avoir le mail
+                    $member->load($attributes);
                     $this->_members[] = $member;
                 }
             }

--- a/src/Api/Gn/User.php
+++ b/src/Api/Gn/User.php
@@ -200,7 +200,7 @@ class User extends Mce\User {
    */
   protected function setMapOutofoffices($OofObjects) {
     M2Log::Log(M2Log::LEVEL_DEBUG, $this->get_class . "->setMapOutofoffices()");
-    $reponses = is_array($this->getObjectMelanie()->outofoffices)?$this->getObjectMelanie()->outofoffices:[];
+    $reponses = $this->objectmelanie->outofoffices??[];
     if (is_array($OofObjects)) {
       foreach ($OofObjects as $OofObject) {
         $reponses[] = $OofObject->render();

--- a/src/Api/Gn/User.php
+++ b/src/Api/Gn/User.php
@@ -200,7 +200,7 @@ class User extends Mce\User {
    */
   protected function setMapOutofoffices($OofObjects) {
     M2Log::Log(M2Log::LEVEL_DEBUG, $this->get_class . "->setMapOutofoffices()");
-    $reponses = $this->getObjectMelanie()->outofoffices;
+    $reponses = is_array($this->getObjectMelanie()->outofoffices)?$this->getObjectMelanie()->outofoffices:[];
     if (is_array($OofObjects)) {
       foreach ($OofObjects as $OofObject) {
         $reponses[] = $OofObject->render();

--- a/src/Api/Gn/User.php
+++ b/src/Api/Gn/User.php
@@ -1,12 +1,12 @@
 <?php
 /**
  * Ce fichier est développé pour la gestion de la lib MCE
- * 
+ *
  * Cette Librairie permet d'accèder aux données sans avoir à implémenter de couche SQL
  * Des objets génériques vont permettre d'accèder et de mettre à jour les données
- * 
+ *
  * ORM Mél Copyright © 2021 Groupe Messagerie/MTE
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -29,13 +29,13 @@ use LibMelanie\Config\MappingMce;
 /**
  * Classe utilisateur pour GN
  * basé sur le User MCE
- * 
+ *
  * @author Groupe Messagerie/MTE - Apitech
  * @package LibMCE
  * @subpackage API/GN
  * @api
- * 
- * @property string $dn DN de l'utilisateur dans l'annuaire            
+ *
+ * @property string $dn DN de l'utilisateur dans l'annuaire
  * @property string $uid Identifiant unique de l'utilisateur
  * @property string $fullname Nom complet de l'utilisateur
  * @property string $name Nom de l'utilisateur
@@ -53,13 +53,13 @@ use LibMelanie\Config\MappingMce;
  * @property array $server_routage Champ de routage pour le serveur de message de l'utilisateur
  * @property-read string $server_host Host du serveur de messagerie de l'utilisateur
  * @property-read string $server_user User du serveur de messagerie de l'utilisateur
- * 
+ *
  * @property-read boolean $is_objectshare Est-ce que cet utilisateur est en fait un objet de partage
  * @property-read ObjectShare $objectshare Retourne l'objet de partage lié à cet utilisateur si s'en est un
- * 
+ *
  * @property-read boolean $is_synchronisation_enable Est-ce que la synchronisation est activée pour l'utilisateur ?
  * @property-read string $synchronisation_profile Profil de synchronisation positionné pour l'utilisateur (STANDARD ou SENSIBLE)
- * 
+ *
  * @method string getTimezone() [OSOLETE] Chargement du timezone de l'utilisateur
  * @method bool authentification($password, $master = false) Authentification de l'utilisateur sur l'annuaire Mélanie2
  * @method bool save() Enregistrement de l'utilisateur dans l'annuaire
@@ -91,6 +91,11 @@ class User extends Mce\User {
     "memberof"                => [MappingMce::name => 'memberof', MappingMce::type => MappingMce::arrayLdap],
     "outofoffices"            => [MappingMce::name => 'mcevacation', MappingMce::type => MappingMce::arrayLdap], // Affichage du message d'absence de l'utilisateur
     "mcemailroutingaddress"   => [MappingMce::name => 'mcemailroutingaddress', MappingMce::type => MappingMce::arrayLdap], // routegemceadrressmail host
+    "deliverymode"   => [MappingMce::name => 'deliverymode', MappingMce::type => MappingMce::stringLdap],
+    "codeunite"   => [MappingMce::name => 'codeunite'],
+    "displayname"   => 'displayname',
+    "employeenumber"   => 'employeenumber',
+    "givenname"   => 'givenname',
   ];
 
   /**
@@ -142,7 +147,7 @@ class User extends Mce\User {
 
   /**
    * Mapping shares field
-   * 
+   *
    * @return Share[] Liste des partages positionnés sur cette boite
    */
   protected function getMapShares() {
@@ -162,7 +167,7 @@ class User extends Mce\User {
 
   /**
    * Mapping shares field
-   * 
+   *
    * @return array Liste des partages supportés par cette boite ([Share::TYPE_*])
    */
   protected function getMapSupported_shares() {

--- a/src/Api/Gn/User.php
+++ b/src/Api/Gn/User.php
@@ -93,9 +93,9 @@ class User extends Mce\User {
     "mcemailroutingaddress"   => [MappingMce::name => 'mcemailroutingaddress', MappingMce::type => MappingMce::arrayLdap], // routegemceadrressmail host
     "deliverymode"   => [MappingMce::name => 'deliverymode', MappingMce::type => MappingMce::stringLdap],
     "codeunite"   => [MappingMce::name => 'codeunite'],
-    "displayname"   => 'displayname',
+    "displayname"   => 'displayname', //todo => usage name => displayname pour tester répercussion
     "employeenumber"   => 'employeenumber',
-    "givenname"   => 'givenname',
+    "givenname"   => 'givenname', //todo usage firstname => givenname, (lastname =>sn), tester usage , où en ai je eu besoin??
   ];
 
   /**
@@ -205,7 +205,7 @@ class User extends Mce\User {
    */
   protected function setMapOutofoffices($OofObjects) {
     M2Log::Log(M2Log::LEVEL_DEBUG, $this->get_class . "->setMapOutofoffices()");
-    $reponses = $this->objectmelanie->outofoffices??[];
+    $reponses = [];
     if (is_array($OofObjects)) {
       foreach ($OofObjects as $OofObject) {
         $reponses[] = $OofObject->render();

--- a/src/Api/Gn/User.php
+++ b/src/Api/Gn/User.php
@@ -67,7 +67,9 @@ use LibMelanie\Config\MappingMce;
  * @method bool exists() Est-ce que l'utilisateur existe dans l'annuaire Mélanie2 (en fonction de l'uid ou l'email)
  */
 class User extends Mce\User {
-	/**
+    const LOAD_ATTRIBUTES = ['fullname', 'uid', 'name', 'email', 'email_list', 'email_send', 'email_send_list', 'server_routage', 'shares', 'type','mcemailroutingaddress','outofoffices'];
+
+    /**
    * Configuration du mapping qui surcharge la conf
    */
   const MAPPING = [
@@ -88,6 +90,7 @@ class User extends Mce\User {
     "title"                   => 'title',                         // Titre
     "memberof"                => [MappingMce::name => 'memberof', MappingMce::type => MappingMce::arrayLdap],
     "outofoffices"            => [MappingMce::name => 'mcevacation', MappingMce::type => MappingMce::arrayLdap], // Affichage du message d'absence de l'utilisateur
+    "mcemailroutingaddress"   => [MappingMce::name => 'mcemailroutingaddress', MappingMce::type => MappingMce::arrayLdap], // routegemceadrressmail host
   ];
 
   /**
@@ -131,22 +134,8 @@ class User extends Mce\User {
     $this->_shares = $shares;
     $_shares = [];
     foreach ($shares as $share) {
-      $right = '';
-      switch ($share->type) {
-        case Share::TYPE_ADMIN:
-          $right = 'G';
-          break;
-        case Share::TYPE_SEND:
-          $right = 'C';
-          break;
-        case Share::TYPE_WRITE:
-          $right = 'E';
-          break;
-        case Share::TYPE_READ:
-          $right = 'L';
-          break;
-      }
-      $_shares[] = $share->user . ':' . $right;
+        $right = $share->type;
+        $_shares[] = $share->user . ':' . $right;
     }
     $this->objectmelanie->shares = $_shares;
   }
@@ -164,20 +153,7 @@ class User extends Mce\User {
       foreach ($_shares as $_share) {
         $share = new Share();
         list($share->user, $right) = \explode(':', $_share, 2);
-        switch (\strtoupper($right)) {
-          case 'G':
-            $share->type = Share::TYPE_ADMIN;
-            break;
-          case 'C':
-            $share->type = Share::TYPE_SEND;
-            break;
-          case 'E':
-            $share->type = Share::TYPE_WRITE;
-            break;
-          case 'L':
-            $share->type = Share::TYPE_READ;
-            break;
-        }
+        $share->type = \strtoupper($right);
         $this->_shares[$share->user] = $share;
       }
     }
@@ -195,7 +171,7 @@ class User extends Mce\User {
 
   /**
    * Récupération du champ out of offices
-   * 
+   *
    * @return Outofoffice[] Tableau de d'objets Outofoffice
    */
   protected function getMapOutofoffices() {
@@ -219,12 +195,12 @@ class User extends Mce\User {
 
   /**
    * Positionnement du champ out of offices
-   * 
+   *
    * @param Outofoffice[] $OofObjects
    */
   protected function setMapOutofoffices($OofObjects) {
     M2Log::Log(M2Log::LEVEL_DEBUG, $this->get_class . "->setMapOutofoffices()");
-    $reponses = [];
+    $reponses = $this->getObjectMelanie()->outofoffices;
     if (is_array($OofObjects)) {
       foreach ($OofObjects as $OofObject) {
         $reponses[] = $OofObject->render();

--- a/src/Objects/UserMelanie.php
+++ b/src/Objects/UserMelanie.php
@@ -1187,7 +1187,14 @@ class UserMelanie extends MagicObject implements IObjectMelanie {
       }
       else if (strpos($itemName, '.') !== false) {
         // Si c'est un itemName par partie on cherche chaque partie dans la conf
-        $parts = explode('.', $itemName);
+        //$parts = explode('.', $itemName);
+        // sam: en accord avec la doc, il faudrait ceci
+          $parts = [$itemName];
+          $pItem = $itemName;
+          while($p = strrchr($pItem, '.')) {
+              $pItem = str_replace($p, "", $pItem);
+              $parts[] = $pItem;
+          }
         foreach ($parts as $part) {
           if (isset($itemsConf[$part])) {
             // Si l'itemName est directement dans la configuration


### PR DESCRIPTION
2 bugs "apparent":
- outofoffice:

la sauvegarde écrase l'enregitsrement de l'attribut mceVacation dans le ldap pour les absences..

le correctif récupère la liste avant sauvegarde pour conserver les anciens enregistrements

- readItemConfiguration:

en accord avec la doc pour la gestion des items, l'explosion de la clé dans la conf"items" n'est pas suffisante..