### PR TITLE
Bugfix/mailbox partage

### DIFF
--- a/src/Api/Gn/ObjectShare.php
+++ b/src/Api/Gn/ObjectShare.php
@@ -21,6 +21,8 @@
 namespace LibMelanie\Api\Gn;
 
 use LibMelanie\Api\Defaut;
+use LibMelanie\Api\Defaut\User;
+use LibMelanie\Log\M2Log;
 
 /**
  * Classe objet partagé LDAP pour GN
@@ -44,4 +46,77 @@ class ObjectShare extends Defaut\ObjectShare {
    * @var string
    */
   const DELIMITER = '.-.';
+
+
+//   /**
+//   * Retourne l'uid de l'utilisateur de l'objet de partage
+//   *
+//   * @return string
+//   */
+//  protected function getMapUser_uid() {
+//    M2Log::Log(M2Log::LEVEL_DEBUG, $this->get_class . "->getMapUser_Uid()");
+//    if (!isset($this->_user_uid)) {
+//        $this->uid;
+//        print $this->uid;die('ok');
+//        preg_match("/(?P<user>.+?)\.\-\.(?P<balp>.+?)@(?P<domain>.+?)/", $this->uid, $m);
+//      $uid = explode(static::DELIMITER, $this->uid, 2);
+//      $this->_user_uid = $uid[0];
+//      $this->_mailbox_uid = $uid[1];
+//    }
+//    return $this->_user_uid;
+//  }
+
+    /**
+     * Retourne la boite mail associée à l'objet de partage
+     *
+     * @return User
+     */
+    protected function getMapMailbox() {
+        M2Log::Log(M2Log::LEVEL_DEBUG, $this->get_class . "->getMapMailbox()");
+        if (!isset($this->_mailbox)) {
+            $uid = explode(static::DELIMITER, $this->uid, 2);
+            $this->_user_uid = $uid[0];
+            $this->_mailbox_uid = $uid[1];
+            $d = explode('@', $this->_mailbox_uid);
+            $this->_user_uid .= "@".$d[1];
+            $class = $this->__getNamespace() . '\\User';
+            $this->_mailbox = new $class($this->_server, $this->_itemName);
+            $this->_mailbox->uid = $this->_mailbox_uid;
+            $this->_mailbox->load();
+//            if (!$this->_mailbox->load()) {
+//                $this->_mailbox = null;
+//            }
+        }
+        return $this->_mailbox;
+    }
+
+      /**
+   * Retourne l'uid de l'utilisateur de l'objet de partage
+   *
+   * @return string
+   */
+  protected function getMapUser_uid() {
+    M2Log::Log(M2Log::LEVEL_DEBUG, $this->get_class . "->getMapUser_Uid()");
+    if (!isset($this->_user_uid)) {
+        $uid = explode(static::DELIMITER, $this->uid, 2);
+        $this->_user_uid = $uid[0];
+        $this->_mailbox_uid = $uid[1];
+        $d = explode('@', $this->_mailbox_uid);
+        $this->_user_uid .= "@".$d[1];
+    }
+    return $this->_user_uid;
+  }
+
+    /**
+   * Retourne l'uid de la boite possedant l'objet de partage
+   *
+   * @return string
+   */
+  protected function getMapMailbox_uid() {
+    M2Log::Log(M2Log::LEVEL_DEBUG, $this->get_class . "->getMapMailbox_uid()");
+    if (!isset($this->_mailbox_uid)) {
+        $this->_mailbox_uid = $this->mailbox->uid;
+    }
+    return $this->_mailbox_uid;
+  }
 }

--- a/src/Api/Gn/ObjectShare.php
+++ b/src/Api/Gn/ObjectShare.php
@@ -48,24 +48,6 @@ class ObjectShare extends Defaut\ObjectShare {
   const DELIMITER = '.-.';
 
 
-//   /**
-//   * Retourne l'uid de l'utilisateur de l'objet de partage
-//   *
-//   * @return string
-//   */
-//  protected function getMapUser_uid() {
-//    M2Log::Log(M2Log::LEVEL_DEBUG, $this->get_class . "->getMapUser_Uid()");
-//    if (!isset($this->_user_uid)) {
-//        $this->uid;
-//        print $this->uid;die('ok');
-//        preg_match("/(?P<user>.+?)\.\-\.(?P<balp>.+?)@(?P<domain>.+?)/", $this->uid, $m);
-//      $uid = explode(static::DELIMITER, $this->uid, 2);
-//      $this->_user_uid = $uid[0];
-//      $this->_mailbox_uid = $uid[1];
-//    }
-//    return $this->_user_uid;
-//  }
-
     /**
      * Retourne la boite mail associée à l'objet de partage
      *
@@ -83,9 +65,6 @@ class ObjectShare extends Defaut\ObjectShare {
             $this->_mailbox = new $class($this->_server, $this->_itemName);
             $this->_mailbox->uid = $this->_mailbox_uid;
             $this->_mailbox->load();
-//            if (!$this->_mailbox->load()) {
-//                $this->_mailbox = null;
-//            }
         }
         return $this->_mailbox;
     }

--- a/src/Api/Gn/User.php
+++ b/src/Api/Gn/User.php
@@ -154,7 +154,7 @@ class User extends Mce\User {
 
   /**
    * Mapping shares field
-   * 
+   *
    * @return Share[] Liste des partages positionnés sur cette boite
    */
   protected function getMapShares() {

--- a/src/Api/Gn/User.php
+++ b/src/Api/Gn/User.php
@@ -154,7 +154,7 @@ class User extends Mce\User {
 
   /**
    * Mapping shares field
-   *
+   * 
    * @return Share[] Liste des partages positionnés sur cette boite
    */
   protected function getMapShares() {


### PR DESCRIPTION
Le Hack ci dessous pour la GN résout pas mal de soucis sur le webmail:

 son isolement au namespace GN n'impacte en rien son utilisation mais sa pertinence reste à ton appréciation..

Le problème:

à différents endroits du plugin mel_moncompte et mel_sharedmailboxes, l'objet $user est écrasé par son objectshare->mailbox. ou un appel aux attribut user_uid & mailbox_uid de l'objet .

l'uid lié (pour vous uid, pour nous c'est le mail) n'applique pas dans tous les cas le bon "id":
- on se retrouve avec un uid (pas mail) et empêche donc le load() de l'objet (null)

en remontant au plus haut j'espère, je rectifie ici la façon dont est construit objectshare et ses appels aux attribut : 
- user_uid = mail pour nous
- mailbox_uid = mail pour nous

La 1ère spécification qu'on m'avait donné à l'origine était que le mail est l'unique référence uid=id permettant les connexions imap, du coup, ce hack semble bien fonctionner de mon côté...

Cependant, je pense que ta vision plus globale aurais peut être joué autrement mais je me suis arrêté là...

